### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ and flexible.
 - `Product Documentation`_
 
 .. |ga| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#ga-support
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#ga-support
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-vpc-access.svg
    :target: https://pypi.org/project/google-cloud-vpc-access/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-vpc-access.svg
@@ -80,4 +80,4 @@ Next Steps
    APIs that we cover.
 
 .. _VPC Access Product documentation:  https://cloud.google.com/vpc/docs
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.