### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "vpcaccess",
     "name_pretty": "Virtual Private Cloud",
     "product_documentation": "https://cloud.google.com/vpc/",
-    "client_documentation": "https://googleapis.dev/python/vpcaccess/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/vpcaccess/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ and flexible.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-vpc-access.svg
    :target: https://pypi.org/project/google-cloud-vpc-access/
 .. _Google Cloud Virtual Private Cloud (VPC): https://cloud.google.com/vpc/
-.. _Client Library Documentation: https://googleapis.dev/python/vpcaccess/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/vpcaccess/latest
 .. _Product Documentation:  https://cloud.google.com/vpc/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.