### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### [1.3.1](https://github.com/googleapis/python-vpc-access/compare/v1.3.0...v1.3.1) (2022-03-05)
+## [1.3.1](https://github.com/googleapis/python-vpc-access/compare/v1.3.0...v1.3.1) (2022-03-05)
 
 
 ### Bug Fixes
@@ -19,7 +19,7 @@
 
 * resolve DuplicateCredentialArgs error when using credentials_file ([6d4115c](https://github.com/googleapis/python-vpc-access/commit/6d4115c40217796cc5797be421889704777edb8d))
 
-### [1.2.1](https://www.github.com/googleapis/python-vpc-access/compare/v1.2.0...v1.2.1) (2021-11-01)
+## [1.2.1](https://www.github.com/googleapis/python-vpc-access/compare/v1.2.0...v1.2.1) (2021-11-01)
 
 
 ### Bug Fixes
@@ -46,14 +46,14 @@
 
 * add context manager support in client ([#51](https://www.github.com/googleapis/python-vpc-access/issues/51)) ([f031d91](https://www.github.com/googleapis/python-vpc-access/commit/f031d910e7924ae6db9ac20bf26a38b74e36597f))
 
-### [1.0.2](https://www.github.com/googleapis/python-vpc-access/compare/v1.0.1...v1.0.2) (2021-09-30)
+## [1.0.2](https://www.github.com/googleapis/python-vpc-access/compare/v1.0.1...v1.0.2) (2021-09-30)
 
 
 ### Bug Fixes
 
 * improper types in pagers generation ([294b2da](https://www.github.com/googleapis/python-vpc-access/commit/294b2da2a2161b7e84ce011780e7f25bc8bd7184))
 
-### [1.0.1](https://www.github.com/googleapis/python-vpc-access/compare/v1.0.0...v1.0.1) (2021-09-24)
+## [1.0.1](https://www.github.com/googleapis/python-vpc-access/compare/v1.0.0...v1.0.1) (2021-09-24)
 
 
 ### Bug Fixes
@@ -68,7 +68,7 @@
 
 * bump release level to production/stable ([#29](https://www.github.com/googleapis/python-vpc-access/issues/29)) ([6e8f2b1](https://www.github.com/googleapis/python-vpc-access/commit/6e8f2b1a5abd697da122854f8fee4c8d3cb00383))
 
-### [0.2.1](https://www.github.com/googleapis/python-vpc-access/compare/v0.2.0...v0.2.1) (2021-07-26)
+## [0.2.1](https://www.github.com/googleapis/python-vpc-access/compare/v0.2.0...v0.2.1) (2021-07-26)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed. Towards b/231248807.